### PR TITLE
hacktoberfest! omniauth-github integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'pry'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 gem 'omniauth'
+gem 'omniauth-github', '~> 1.1', '>= 1.1.2'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     dotenv (2.1.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -69,6 +71,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jwt (1.5.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -83,13 +86,27 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
+    omniauth-github (1.1.2)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
+    omniauth-oauth2 (1.4.0)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     pg (0.18.4)
     pkg-config (1.1.7)
     pry (0.10.4)
@@ -199,6 +216,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   omniauth
+  omniauth-github (~> 1.1, >= 1.1.2)
   pg
   pry
   puma (~> 3.0)
@@ -214,4 +232,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,17 +6,40 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:email])
-    if user && user.authenticate(params[:password])
-      session[:user_id] = user.id
-      redirect_to users_path, :notice => "Logged in!"
+    auth_hash = request.env['omniauth.auth']
+
+    if auth_hash
+      provider_login(auth_hash)
     else
-      redirect_to new_session_path, alert: "Invalid email or password." 
+      password_login
     end
   end
 
   def destroy
     session[:user_id] = nil
     redirect_to root_path, :notice => "Logged out!"
+  end
+
+  protected
+
+  def provider_login(auth_hash = {})
+    identity = Identity.for_auth(auth_hash)
+    if identity.empty?
+      session[:auth_hash] = auth_hash
+      redirect_to signup_path, :notice => "Github authentication successful, but you must still complete the sign up form."
+    else
+      session[:user_id] = identity.first.user_id
+      redirect_to users_path, :notice => "Logged in!"
+    end
+  end
+
+  def password_login
+    user = User.find_by(email: params[:email])
+    if user && user.authenticate(params[:password])
+      session[:user_id] = user.id
+      redirect_to users_path, :notice => "Logged in!"
+    else
+      redirect_to new_session_path, alert: "Invalid email or password."
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,10 +18,13 @@ class UsersController < ApplicationController
     @user = User.create(user_params)
     if @user.save
       session[:user_id] = @user.id
+
+      save_identity
+
       redirect_to users_path, notice: "Signup successful!"
     else
       @errors = @user.errors.full_messages
-      redirect_to new_user_path, notice: "You must be a registered user to do that."
+      redirect_to new_user_path, notice: "You must be a registered user to do that. #{@errors}"
     end
   end
 
@@ -54,5 +57,12 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:username, :email, :password, :gender,
      :gender_seeking, :bio, :question_1, :question_2, :question_3)
+  end
+
+  def save_identity
+    if session[:auth_hash]
+      Identity.for_auth(session[:auth_hash]).create(user: @user)
+      session.delete(:auth_hash)
+    end
   end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,0 +1,5 @@
+class Identity < ApplicationRecord
+  belongs_to :user
+
+  scope :for_auth, -> (auth) { where(uid: auth['uid'], provider: auth['provider'])}
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   has_secure_password
   has_many :conversations, :foreign_key => :sender_id
   has_many :admirers
-  
+  has_many :indentities
+
   validates_presence_of :email, :gender, :gender_seeking, :bio
   validates_uniqueness_of :email
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,6 +3,6 @@
 <span>Welcome, <%=current_user.username %></span> |
   <a href="<%=logout_path%>">Logout</a>
   <% else %>
-    <a href="<%= login_path %>">Login</a> | <a href="<%= signup_path %>"> Sign-Up</a>
+    <a href="<%= login_path %>">Login</a> | <a href="/auth/github">Github Login</a> | <a href="<%= signup_path %>"> Sign-Up</a>
   <% end %>
 </section>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,4 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :developer unless Rails.env.production?
+  provider :github, 'd20abc65d5c0901814ce', 'd46c3dbdaa6ad85fb4091772f739d183ce1c604e'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new", as: "login"
   get "/logout", to: "sessions#destroy", as: "logout"
 
+  get '/auth/:provider/callback', to: 'sessions#create'
+
   root "sessions#new"
 
 end

--- a/db/migrate/20160928081856_create_identities.rb
+++ b/db/migrate/20160928081856_create_identities.rb
@@ -1,0 +1,9 @@
+class CreateIdentities < ActiveRecord::Migration[5.0]
+  def change
+    create_table :identities do |t|
+      t.string :uid
+      t.string :provider
+      t.references :user
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927181445) do
+ActiveRecord::Schema.define(version: 20160928081856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,13 @@ ActiveRecord::Schema.define(version: 20160927181445) do
     t.integer  "recipient_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+  end
+
+  create_table "identities", force: :cascade do |t|
+    t.string  "uid"
+    t.string  "provider"
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_identities_on_user_id", using: :btree
   end
 
   create_table "messages", force: :cascade do |t|

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Identity, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
fixes #29 
You'll need to run rake db:migrate to support the new Identity model, and add your app with Github to get your key and secret key, which need to be defined in environment variables `GITHUB_KEY` and `GITHUB_SECRET`, respectively. A little overkill, but you'd be able to support other providers if desired. I modified the registration flow such that a user attempting to login with Github without having an account would still have to fill out the registration form. The implementation of all this is quick and dirty, but good enough for you to make more robust changes. Enjoy!
